### PR TITLE
Fix/tag modal stays open

### DIFF
--- a/app/journal/index.tsx
+++ b/app/journal/index.tsx
@@ -65,7 +65,6 @@ export default function JournalPage() {
     if (!selectedTags.includes(tag)) {
       setSelectedTags([...selectedTags, tag]);
     }
-    setIsTagModalVisible(false);
   };
 
   const getTagColor = (tag: string) => {


### PR DESCRIPTION
Fix:

- Allow the tag modal to stay open while user selects multiple tags